### PR TITLE
* fix setting of translation message placeholders in case of missing …

### DIFF
--- a/src/Spryker/Zed/ShipmentCartConnector/Business/Cart/ShipmentCartValidator.php
+++ b/src/Spryker/Zed/ShipmentCartConnector/Business/Cart/ShipmentCartValidator.php
@@ -180,7 +180,7 @@ class ShipmentCartValidator implements ShipmentCartValidatorInterface
     protected function createMessage(ShipmentMethodTransfer $shipmentMethodTransfer): MessageTransfer
     {
         return (new MessageTransfer())
-            ->addParameters([
+            ->setParameters([
                 '%method_name%' => $shipmentMethodTransfer->getName(),
                 '%carrier_name%' => $shipmentMethodTransfer->getCarrierName(),
             ])


### PR DESCRIPTION
…shipment

## PR Description

During translation of the missing shipment method, an exception will be thrown. This is due to `(new MessageTransfer())->addParameters()`, which will add a nested array to the parameters array. Instead, `(new MessageTransfer())->setParameters()` should be used to fix this.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
